### PR TITLE
Fix canonical URL without query params

### DIFF
--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -20,7 +20,8 @@ export default function SEO({
   type = 'website',
 }: SEOProps) {
   const [location] = useLocation();
-  const canonicalUrl = `${BASE_URL}${location === '/' ? '' : location}`;
+  const canonicalPath = location.split(/[?#]/)[0];
+  const canonicalUrl = `${BASE_URL}${canonicalPath === '/' ? '' : canonicalPath}`;
 
   return (
     <Helmet>


### PR DESCRIPTION
## Summary
- avoid query/hash strings in canonical URL generation

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6840436fda608328b6c04d2d4058447f