### PR TITLE
Fix SEO meta image URLs

### DIFF
--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -23,6 +23,8 @@ export default function SEO({
   const canonicalPath = location.split(/[?#]/)[0];
   const canonicalUrl = `${BASE_URL}${canonicalPath === '/' ? '' : canonicalPath}`;
 
+  const imageUrl = image.startsWith('http') ? image : `${BASE_URL}${image.startsWith('/') ? '' : '/'}${image}`;
+
   return (
     <Helmet>
       {/* Canonical URL */}
@@ -38,14 +40,14 @@ export default function SEO({
       <meta property="og:url" content={canonicalUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={image} />
+      <meta property="og:image" content={imageUrl} />
       
       {/* Twitter */}
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content={canonicalUrl} />
       <meta property="twitter:title" content={title} />
       <meta property="twitter:description" content={description} />
-      <meta property="twitter:image" content={image} />
+      <meta property="twitter:image" content={imageUrl} />
     </Helmet>
   );
 } 

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -7,10 +7,10 @@ import manuImage from "@assets/about_pics/manu-pic.webp";
 export default function About() {
   return (
     <>
-      <SEO 
+      <SEO
         title="About The Aevia - Meet Our Doctor-Led Team"
         description="Meet the doctor-led team behind The Aevia. Our founders combine medical expertise with a passion for natural results and transformative coaching in Kings Cross, London."
-        image="/about_pics/terrell-pic3.webp"
+        image={terrellImage}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/Consultations.tsx
+++ b/client/src/pages/Consultations.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Check } from "lucide-react";
 import SEO from "@/components/SEO";
+import clinicHeroImage from "@assets/hero_images/aevia-clinic2.webp";
 
 export default function Consultations() {
   const [location, setLocation] = useLocation();
@@ -51,10 +52,10 @@ export default function Consultations() {
 
   return (
     <>
-      <SEO 
+      <SEO
         title="Book Your Consultation - The Aevia"
         description="Book your personalized consultation with our expert doctors. Choose between medical aesthetics and performance coaching consultations at our Kings Cross clinic."
-        image="/hero_images/aevia-clinic2.webp"
+        image={clinicHeroImage}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -12,10 +12,10 @@ import skinModel2 from "@assets/hero_images/skin-model-2.webp";
 export default function Home() {
   return (
     <>
-      <SEO 
+      <SEO
         title="The Aevia - Doctor-Led Transformation for Skin and Mind"
         description="Medical aesthetics and performance coaching for professionals who demand excellence. Based in Kings Cross, London. Book your consultation today."
-        image="/aevia-clinic3.webp"
+        image={clinicImage}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/JournalReal.tsx
+++ b/client/src/pages/JournalReal.tsx
@@ -3,14 +3,15 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Link } from "wouter";
 import { Calendar, Clock, Tag } from "lucide-react";
 import SEO from "@/components/SEO";
+import clinicHeroImage from "@assets/hero_images/aevia-clinic3.webp";
 
 export default function Journal() {
   return (
     <>
-      <SEO 
+      <SEO
         title="The Aevia Journal - Expert Insights on Skin & Mind"
         description="Explore our journal for expert insights on medical aesthetics, performance coaching, and holistic wellness. Stay informed with the latest research and trends from our doctor-led team."
-        image="/hero_images/aevia-clinic3.webp"
+        image={clinicHeroImage}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/Mind.tsx
+++ b/client/src/pages/Mind.tsx
@@ -9,10 +9,10 @@ import SEO from "@/components/SEO";
 export default function Mind() {
   return (
     <>
-      <SEO 
+      <SEO
         title="Aevia Mind - Performance & Transformative Coaching"
         description="Doctor-led performance coaching for professionals seeking clarity, confidence, and agency. Transform your mindset and achieve your full potential with our evidence-based approach."
-        image="/hero_images/mind-hero.webp"
+        image={mindHeroImage}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/Reviews.tsx
+++ b/client/src/pages/Reviews.tsx
@@ -4,14 +4,15 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Star, Quote } from "lucide-react";
 import SEO from "@/components/SEO";
+import reviewsHero from "@assets/hero_images/reviews-hero.webp";
 
 export default function Reviews() {
   return (
     <>
-      <SEO 
+      <SEO
         title="Client Reviews - The Aevia"
         description="Read authentic reviews from our clients about their experiences with our medical aesthetics treatments and performance coaching at The Aevia clinic in Kings Cross."
-        image="/hero_images/reviews-hero.webp"
+        image={reviewsHero}
       />
       <div className="min-h-screen py-20">
         <div className="max-w-6xl mx-auto px-6">

--- a/client/src/pages/Skin.tsx
+++ b/client/src/pages/Skin.tsx
@@ -3,15 +3,16 @@ import { Button } from "@/components/ui/button";
 import { Dna, Droplet, Sparkles, Clock, Check, Banknote } from "lucide-react";
 import { BookingButton } from "@/components/BookingButton";
 import skinModelImage from "@assets/hero_images/skin-model.webp";
+import skinModelSeo from "@assets/hero_images/skin-model-2.webp";
 import SEO from "@/components/SEO";
 
 export default function Skin() {
   return (
     <>
-      <SEO 
+      <SEO
         title="Aevia Skin - Medical Aesthetics & Regenerative Treatments"
         description="Experience science-backed skin rejuvenation with our doctor-led medical aesthetics. From polynucleotides to skin boosters, discover treatments that enhance your natural beauty."
-        image="/hero_images/skin-model-2.webp"
+        image={skinModelSeo}
       />
       <div className="min-h-screen">
         {/* Hero Section */}

--- a/client/src/pages/Treatments.tsx
+++ b/client/src/pages/Treatments.tsx
@@ -4,6 +4,7 @@ import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import SEO from "@/components/SEO";
+import skinModelSeo from "@assets/hero_images/skin-model-2.webp";
 
 interface Treatment {
   name: string;
@@ -297,10 +298,10 @@ export default function Treatments() {
 
   return (
     <>
-      <SEO 
+      <SEO
         title="Medical Aesthetics Treatments - The Aevia"
         description="Discover our range of doctor-led medical aesthetics treatments. From polynucleotides to skin boosters, experience science-backed treatments for natural, lasting results."
-        image="/hero_images/skin-model-2.webp"
+        image={skinModelSeo}
       />
       <div className="min-h-screen">
         {/* Hero Section */}


### PR DESCRIPTION
## Summary
- ensure SEO component outputs absolute OG image URLs
- pass hashed image paths to SEO across pages

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68422d8ab4308328a489b75e86a17300