### PR TITLE
Fix canonical URLs to include query strings

### DIFF
--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -21,7 +21,8 @@ export default function SEO({
   type = 'website',
 }: SEOProps) {
   const [location] = useLocation();
-  const canonicalPath = location.split(/[?#]/)[0];
+  // Preserve query parameters in the canonical URL but strip hash fragments
+  const canonicalPath = location.split('#')[0];
   const canonicalUrl = `${BASE_URL}${canonicalPath === '/' ? '' : canonicalPath}`;
 
   return (

--- a/server/index.ts
+++ b/server/index.ts
@@ -184,7 +184,8 @@ app.post('/api/csp-report', express.json({ type: 'application/csp-report' }), (r
 
       // Fallback to index.html for client-side routing
       app.get('*', (req, res) => {
-        const canonicalUrl = `${BASE_URL}${req.path === '/' ? '' : req.path}`;
+        const pathWithQuery = req.originalUrl.split('#')[0];
+        const canonicalUrl = `${BASE_URL}${pathWithQuery === '/' ? '' : pathWithQuery}`;
         // Set both header and HTML for canonical URL
         res.setHeader('Link', `<${canonicalUrl}>; rel="canonical"`);
         


### PR DESCRIPTION
## Summary
- keep query params in canonical URL on the client SEO component
- include query params when generating canonical URLs in the server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684857de8a188328852f11befa675dd5