### PR TITLE
Fix vite config usage

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfigFn from "../vite.config";
 import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
@@ -25,8 +25,13 @@ export async function setupVite(app: Express, server: Server) {
     hmr: { server }
   };
 
+  const resolvedConfig = await (viteConfigFn as any)({
+    command: 'serve',
+    mode: process.env.NODE_ENV ?? 'development'
+  });
+
   const vite = await createViteServer({
-    ...viteConfig,
+    ...resolvedConfig,
     configFile: false,
     customLogger: {
       ...viteLogger,


### PR DESCRIPTION
## Summary
- load Vite configuration by calling exported config function

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6848676266488328bb85bf4cd8b88e40