### PR TITLE
Fix sitemap domain to www

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <!-- Home page -->
   <url>
-    <loc>https://theaevia.co.uk/</loc>
+    <loc>https://www.theaevia.co.uk/</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
@@ -10,44 +10,44 @@
 
   <!-- Main pages -->
   <url>
-    <loc>https://theaevia.co.uk/about</loc>
+    <loc>https://www.theaevia.co.uk/about</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://theaevia.co.uk/treatments</loc>
+    <loc>https://www.theaevia.co.uk/treatments</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>https://theaevia.co.uk/consultations</loc>
+    <loc>https://www.theaevia.co.uk/consultations</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>https://theaevia.co.uk/skin</loc>
+    <loc>https://www.theaevia.co.uk/skin</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://theaevia.co.uk/mind</loc>
+    <loc>https://www.theaevia.co.uk/mind</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://theaevia.co.uk/journal</loc>
+    <loc>https://www.theaevia.co.uk/journal</loc>
     <lastmod>2024-03-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-</urlset> 
+</urlset>


### PR DESCRIPTION
## Summary
- update sitemap `<loc>` tags to use `https://www.theaevia.co.uk`
- remove trailing spaces and add newline at EOF

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68488b7482488328948c2f706f4650c9