### PR TITLE
Fix trailing space in robots.txt

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -4,4 +4,4 @@ Disallow: /staging/
 Disallow: /test/
 Allow: /
 
-Sitemap: https://www.theaevia.co.uk/sitemap.xml 
+Sitemap: https://www.theaevia.co.uk/sitemap.xml


### PR DESCRIPTION
## Summary
- remove trailing space from `client/public/robots.txt`
- ensure file ends with a newline

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68488d4c3dd88328a5b4e7b7aadf8189