### PR TITLE
Add Google Maps widget

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 # Server Configuration
 PORT=3001
 NODE_ENV=development
+VITE_EMBED_KEY=AIzaSyCDgTsuub3PQLTOFCUWH62hG7_MCw-JVaY

--- a/client/src/components/LocationMap.tsx
+++ b/client/src/components/LocationMap.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const MAP_SRC = `https://www.google.com/maps/embed/v1/place?key=${import.meta.env.VITE_EMBED_KEY}&q=51.5310793,-0.1203023&zoom=17`;
+
+export default function LocationMap() {
+  return (
+    <div className="w-full h-96">
+      <iframe
+        title="The Aevia – King's Cross"
+        src={MAP_SRC}
+        className="w-full h-full border-0 rounded-2xl"
+        loading="lazy"
+        allowFullScreen
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+    </div>
+  );
+}

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -5,6 +5,7 @@ import reneeImage from "@assets/about_pics/renee-pic.webp";
 import manuImage from "@assets/about_pics/manu-pic.webp";
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
+import LocationMap from "@/components/LocationMap";
 
 export default function About() {
   return (
@@ -216,6 +217,9 @@ export default function About() {
                   </Link>
                 </div>
               </div>
+            </div>
+            <div className="mt-12">
+              <LocationMap />
             </div>
           </div>
         </section>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { Leaf, Brain, Star } from "lucide-react";
 import TestimonialCard from "@/components/TestimonialCard";
 import ServiceCard from "@/components/ServiceCard";
 import { BookingButton } from "@/components/BookingButton";
+import LocationMap from "@/components/LocationMap";
 import SEO from "@/components/SEO";
 import clinicImage from "@assets/hero_images/aevia-clinic3.webp";
 import clinicImage800 from "@assets/hero_images/aevia-clinic3-800w.webp";
@@ -233,6 +234,12 @@ transformation.
                 </Button>
               </a>
             </div>
+          </div>
+        </section>
+
+        <section className="py-20 bg-secondary">
+          <div className="max-w-4xl mx-auto px-6">
+            <LocationMap />
           </div>
         </section>
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,7 +30,14 @@ app.use(helmet({
       ...helmet.contentSecurityPolicy.getDefaultDirectives(),
       "default-src": ["'self'"],
       "img-src": ["'self'", "data:", "https:", "blob:"],
-      "frame-src": ["'self'", "https://calendly.com", "https://www.calendly.com", "https://assets.calendly.com", "https://www.googletagmanager.com"],
+      "frame-src": [
+        "'self'",
+        "https://calendly.com",
+        "https://www.calendly.com",
+        "https://assets.calendly.com",
+        "https://www.googletagmanager.com",
+        "https://www.google.com"
+      ],
       "connect-src": [
         "'self'",
         "https://calendly.com",


### PR DESCRIPTION
## Summary
- embed Google Maps with LocationMap component
- show map on home and about pages
- allow google.com in Content Security Policy
- store maps embed key in `.env`

## Testing
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684a0fe31cc48328b375922c369829ab