### PR TITLE
Embed Google Maps

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 # Server Configuration
 PORT=3001
 NODE_ENV=development
+VITE_EMBED_KEY=AIzaSyCDgTsuub3PQLTOFCUWH62hG7_MCw-JVaY

--- a/client/src/components/LocationMap.tsx
+++ b/client/src/components/LocationMap.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const MAP_SRC = `https://www.google.com/maps/embed/v1/place?key=${import.meta.env.VITE_EMBED_KEY}&q=51.5310793,-0.1203023&zoom=17`;
+
+export default function LocationMap() {
+  return (
+    <div className="w-full h-96">
+      <iframe
+        title="The Aevia – King's Cross"
+        src={MAP_SRC}
+        className="w-full h-full border-0 rounded-2xl"
+        loading="lazy"
+        allowFullScreen
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+    </div>
+  );
+}

--- a/client/src/pages/Clinic.tsx
+++ b/client/src/pages/Clinic.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import SEO from "@/components/SEO";
 import { Link } from "wouter";
+import LocationMap from "@/components/LocationMap";
 
 export default function Clinic() {
   return (
@@ -71,6 +72,12 @@ export default function Clinic() {
                 </div>
               </div>
             </div>
+          </div>
+        </section>
+
+        <section className="bg-white py-12">
+          <div className="max-w-4xl mx-auto px-6">
+            <LocationMap />
           </div>
         </section>
       </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import clinicImage from "@assets/hero_images/aevia-clinic3.webp";
 import clinicImage800 from "@assets/hero_images/aevia-clinic3-800w.webp";
 import mindCoachingStairs from "@assets/hero_images/mind-coaching-water.webp";
 import skinModel4 from "@assets/hero_images/royalty-free-skin4.webp";
+import LocationMap from "@/components/LocationMap";
 
 export default function Home() {
   return (
@@ -254,6 +255,12 @@ transformation.
                 </BookingButton>
               </div>
             </div>
+          </div>
+        </section>
+
+        <section className="py-20 bg-white">
+          <div className="max-w-4xl mx-auto px-6">
+            <LocationMap />
           </div>
         </section>
       </div>

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,7 +30,14 @@ app.use(helmet({
       ...helmet.contentSecurityPolicy.getDefaultDirectives(),
       "default-src": ["'self'"],
       "img-src": ["'self'", "data:", "https:", "blob:"],
-      "frame-src": ["'self'", "https://calendly.com", "https://www.calendly.com", "https://assets.calendly.com", "https://www.googletagmanager.com"],
+      "frame-src": [
+        "'self'",
+        "https://calendly.com",
+        "https://www.calendly.com",
+        "https://assets.calendly.com",
+        "https://www.googletagmanager.com",
+        "https://www.google.com",
+      ],
       "connect-src": [
         "'self'",
         "https://calendly.com",


### PR DESCRIPTION
## Summary
- add a `LocationMap` component for Google Maps embed
- show map on the Home and Clinic pages
- permit google.com in the Content Security Policy
- include VITE_EMBED_KEY in environment config

## Testing
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684a128c65508328af29fdff84714107